### PR TITLE
Three distributor issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ For the management calls, the process needs to have the `CAP_NET_BIND_SERVICE` c
     * _Read._ Return the ASCII-encoded SSID of current wifi connected to the unit
   * Set Wifi Connection characteristic `5c305a16-6859-4d6c-a87b-8d2c98c9f6f0`
     * _Write._ Send in wifi SSID and Password in the json string form e.g. "{\"network\":\"Wifi-4A91D0\",\"password\":\"somePassword\"}" response on success will be the network name
+  * Get IMSI characteristic `5c305a21-6859-4d6c-a87b-8d2c98c9f6f0`
+    * _Read._ Return the ASCII-encoded IMSI of the SIM card
 * Vehicle service `5c30d387-6859-4d6c-a87b-8d2c98c9f6f0`
   * Get VIN characteristic `5c300acc-6859-4d6c-a87b-8d2c98c9f6f0`
     * _Read._ Return the ASCII-encoded VIN

--- a/commands/api.go
+++ b/commands/api.go
@@ -41,8 +41,10 @@ type executeRawRequest struct {
 }
 
 // For some reason, this only gets returned for some calls.
+// Sometimes it's "value", sometimes "data".
 type executeRawResponse struct {
 	Value string `json:"value"`
+	Data  string `json:"data"`
 }
 
 type GenericSignalStrengthResponse struct {
@@ -181,9 +183,16 @@ func executeRequest(method, path string, reqVal, respVal any) (err error) {
 		return fmt.Errorf("status code %d", c)
 	}
 
+	// Ignore any response.
 	if respVal == nil {
 		return
 	}
-	err = json.NewDecoder(resp.Body).Decode(respVal)
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(b, respVal)
 	return
 }

--- a/commands/device.go
+++ b/commands/device.go
@@ -184,12 +184,18 @@ func GetIMSI(unitID uuid.UUID) (imsi string, err error) {
 		return
 	}
 
+	var resp executeRawResponse
 	if modem == "ec2x" {
 		req = executeRawRequest{Command: ec2xIMSICommand}
 	} else {
 		req = executeRawRequest{Command: normalIMSICommand}
 	}
 
-	err = executeRequest("POST", url, req, &imsi)
+	err = executeRequest("POST", url, req, &resp)
+	if err != nil {
+		return
+	}
+
+	imsi = resp.Data
 	return
 }

--- a/main.go
+++ b/main.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/google/subcommands"
 	"log"
 	"math"
 	"os"
 	"os/signal"
 	"time"
+
+	"github.com/google/subcommands"
 
 	"github.com/DIMO-Network/edge-network/agent"
 	"github.com/DIMO-Network/edge-network/commands"
@@ -807,10 +808,10 @@ func main() {
 	log.Printf("  Get Software Version characteristic: %s", softwareVersionChar.Properties.UUID)
 	log.Printf("  Set Bluetooth Version characteristic: %s", bluetoothVersionChar.Properties.UUID)
 	log.Printf("  Sleep Control characteristic: %s", sleepControlChar.Properties.UUID)
-
 	log.Printf("  Get Signal Strength characteristic: %s", signalStrengthChar.Properties.UUID)
 	log.Printf("  Get Wifi Connection Status characteristic: %s", wifiStatusChar.Properties.UUID)
 	log.Printf("  Set Wifi Connection characteristic: %s", setWifiChar.Properties.UUID)
+	log.Printf("  Get IMSI characteristic: %s", imsiChar.Properties.UUID)
 
 	log.Printf("Vehicle service: %s", vehicleService.Properties.UUID)
 	log.Printf("  Get VIN characteristic: %s", vinChar.Properties.UUID)


### PR DESCRIPTION
Some stuff needed by the distributor app.

Resolves

* PLA-1387, software version characteristic not working until the release of AutoPi v1.14.0
* PLA-1414, make the Ethereum address viewable without bonding
* PLA-1420, expose the SIM's [IMSI](https://en.wikipedia.org/wiki/International_mobile_subscriber_identity)

I have tested on a 6.1 device. Will test on a 7.0 soon.