### PR TITLE
PRO-1485 better handle errors, do not over retry failures to get VIN

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -184,7 +184,7 @@ func ExecuteRequest(method, path string, reqVal, respVal any) (err error) {
 		if body == nil {
 			body = []byte("no body response.")
 		}
-		return fmt.Errorf("status code %d. bdoy: %s", c, string(body))
+		return fmt.Errorf("status code %d. body: %s", c, string(body))
 	}
 
 	// Ignore any response.

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -44,7 +44,7 @@ func (ls *loggerService) StartLoggers() error {
 	ethAddr, err := commands.GetEthereumAddress(ls.unitID)
 	if err != nil {
 		log.WithError(err).Log(log.ErrorLevel)
-		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, err)
+		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "failed to get device eth addr"))
 	}
 	// read any existing settings
 	config, err := ls.loggerSettingsSvc.ReadConfig()
@@ -60,7 +60,7 @@ func (ls *loggerService) StartLoggers() error {
 		vinResp, err := logger.ScanFunc(ls.unitID, vqn)
 		if err != nil {
 			log.WithError(err).Log(log.ErrorLevel)
-			_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, err)
+			_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "failed to get VIN from logger"))
 			break
 		}
 		// save vin query name in settings if not set
@@ -69,7 +69,7 @@ func (ls *loggerService) StartLoggers() error {
 			err := ls.loggerSettingsSvc.WriteConfig(*config)
 			if err != nil {
 				log.WithError(err).Log(log.ErrorLevel)
-				_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, err)
+				_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "failed to write logger settings"))
 			}
 		}
 		p := network.NewStatusUpdatePayload(ls.unitID, ethAddr)

--- a/internal/logger.go
+++ b/internal/logger.go
@@ -31,35 +31,51 @@ func NewLoggerService(unitID uuid.UUID, vinLog loggers.VINLogger, dataSender net
 
 // StartLoggers checks if ok to start scanning the vehicle and then according to configuration scans and sends data periodically
 func (ls *loggerService) StartLoggers() error {
+	ethAddr, err := commands.GetEthereumAddress(ls.unitID)
+	if err != nil {
+		log.WithError(err).Log(log.ErrorLevel)
+		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "could not get device eth addr"))
+	}
 	// check if ok to start making obd calls etc
 	log.Infof("loggers: starting - checking if can start scanning")
 	ok, status, err := ls.isOkToScan()
 	if err != nil {
+		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "checks to start loggers failed"))
 		return errors.Wrap(err, "checks to start loggers failed, no action")
 	}
 	if !ok {
-		return fmt.Errorf("checks to start loggers failed but no errors reported")
+		e := fmt.Errorf("checks to start loggers failed but no errors reported")
+		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, e)
+		return e
 	}
 	log.Infof("loggers: checks passed to start scanning")
-	ethAddr, err := commands.GetEthereumAddress(ls.unitID)
-	if err != nil {
-		log.WithError(err).Log(log.ErrorLevel)
-		_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "failed to get device eth addr"))
-	}
 	// read any existing settings
 	config, err := ls.loggerSettingsSvc.ReadConfig()
 	if err != nil {
-		log.Printf("failed to read configuration: %s", err)
+		log.Printf("could not read settings, continuing: %s", err)
 	}
 	var vqn *string
 	if config != nil {
 		vqn = &config.VINQueryName
+		// check if we do not want to continue scanning VIN for this car - currently determines if we run any loggers (but do note some cars won't respond VIN but yes on most OBD2 stds)
+		if config.VINLoggerVersion == loggers.VINLoggerVersion { // if vin logger improves, basically ignore failed attempts as maybe we decoded it.
+			if config.VINLoggerFailedAttempts >= 3 {
+				if vqn != nil {
+					// this would be really weird and needs to be addressed
+					// todo: send error payload
+				}
+				return fmt.Errorf("failed attempts for VIN logger exceeded, not starting loggers")
+			}
+		}
 	}
+
 	// loop over loggers and call them. This needs to be reworked to support more than one thing that is not VIN etc
 	for _, logger := range ls.getLoggerConfigs() {
 		vinResp, err := logger.ScanFunc(ls.unitID, vqn)
 		if err != nil {
 			log.WithError(err).Log(log.ErrorLevel)
+			// todo, but don't want to overwrite settings
+			//ls.loggerSettingsSvc.WriteConfig(...)
 			_ = ls.dataSender.SendErrorPayload(ls.unitID, ethAddr, errors.Wrap(err, "failed to get VIN from logger"))
 			break
 		}

--- a/internal/logger_test.go
+++ b/internal/logger_test.go
@@ -129,7 +129,6 @@ func Test_loggerService_StartLoggers_noVINResponseAndAttemptsExceeded(t *testing
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 	const autoPiBaseURL = "http://192.168.4.1:9000"
-	const ethAddr = "b794f5ea0ba39494ce839613fffba74279579268"
 	unitID := uuid.New()
 
 	mockCtrl := gomock.NewController(t)

--- a/internal/logger_test.go
+++ b/internal/logger_test.go
@@ -113,9 +113,50 @@ func Test_loggerService_StartLoggers_noVINResponse(t *testing.T) {
 	noVinErr := fmt.Errorf("response contained an invalid vin")
 	vl.EXPECT().GetVIN(unitID, nil).Times(1).Return(nil, noVinErr)
 	eth := common.HexToAddress(ethAddr)
-	ds.EXPECT().SendErrorPayload(unitID, &eth, noVinErr).Times(1).Return(nil)
+	lss.EXPECT().WriteConfig(loggers.LoggerSettings{
+		VINQueryName:            "",
+		VINLoggerVersion:        loggers.VINLoggerVersion,
+		VINLoggerFailedAttempts: 1,
+	}).Return(nil)
+	ds.EXPECT().SendErrorPayload(unitID, &eth, gomock.Any()).Times(1).Return(nil)
 
 	err := ls.StartLoggers()
 
 	assert.NoError(t, err)
+}
+
+func Test_loggerService_StartLoggers_noVINResponseAndAttemptsExceeded(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+	const autoPiBaseURL = "http://192.168.4.1:9000"
+	const ethAddr = "b794f5ea0ba39494ce839613fffba74279579268"
+	unitID := uuid.New()
+
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	vl := mock_loggers.NewMockVINLogger(mockCtrl)
+	ds := mock_network.NewMockDataSender(mockCtrl)
+	lss := mock_loggers.NewMockLoggerSettingsService(mockCtrl)
+	ls := NewLoggerService(unitID, vl, ds, lss)
+
+	// mock powerstatus resp
+	psPath := fmt.Sprintf("/dongle/%s/execute_raw/", unitID)
+	httpmock.RegisterResponder(http.MethodPost, autoPiBaseURL+psPath,
+		httpmock.NewStringResponder(200, `{"spm": {"last_trigger": {"up": "volt_change"}, "battery": {"voltage": 13.3}}}`))
+	// mock eth addr
+	ethPath := fmt.Sprintf("/dongle/%s/execute_raw", unitID)
+	httpmock.RegisterResponder(http.MethodPost, autoPiBaseURL+ethPath,
+		httpmock.NewStringResponder(200, `{"value": "b794f5ea0ba39494ce839613fffba74279579268"}`))
+
+	// nil settings, eg. first time it runs, incompatiible vehicle
+	lss.EXPECT().ReadConfig().Times(1).Return(&loggers.LoggerSettings{
+		VINQueryName:            "",
+		VINLoggerVersion:        loggers.VINLoggerVersion,
+		VINLoggerFailedAttempts: 3,
+	}, nil)
+
+	err := ls.StartLoggers()
+
+	assert.Error(t, err)
 }

--- a/internal/loggers/logger_settings.go
+++ b/internal/loggers/logger_settings.go
@@ -57,5 +57,7 @@ func (lcs *loggerSettingsService) WriteConfig(settings LoggerSettings) error {
 }
 
 type LoggerSettings struct {
-	VINQueryName string `json:"vin_query_name"`
+	VINQueryName            string `json:"vin_query_name"`
+	VINLoggerVersion        int    `json:"vin_logger_version"`
+	VINLoggerFailedAttempts int    `json:"vin_logger_failed_attempts"`
 }

--- a/internal/loggers/vin_logger.go
+++ b/internal/loggers/vin_logger.go
@@ -26,6 +26,7 @@ func NewVINLogger() VINLogger {
 	return &vinLogger{}
 }
 
+const VINLoggerVersion = 1
 const citroenQueryName = "citroen"
 
 func (vl *vinLogger) GetVIN(unitID uuid.UUID, queryName *string) (vinResp *VINResponse, err error) {
@@ -190,7 +191,7 @@ func findVINLineStart(lines []string) int {
 func passiveScanCitroen() (*VINResponse, error) {
 	vin := ""
 	// unable to get VIN via PID queries, so try passive scan
-	myVinReader := newPassiveVinReader()
+	vinReader := newPassiveVinReader()
 	protocolInt := 0
 
 	// Create a channel to receive the result
@@ -198,7 +199,7 @@ func passiveScanCitroen() (*VINResponse, error) {
 	// Create a channel for the timeout signal
 	timeoutChan := make(chan bool)
 	go func() {
-		vin, protocolInt, _ = myVinReader.ReadCitroenVIN(10000) // todo cleanup logging in this method
+		vin, protocolInt, _ = vinReader.ReadCitroenVIN(10000) // todo cleanup logging in this method
 		resultChan <- vin
 	}()
 	// Start a goroutine to wait for the timeout

--- a/internal/loggers/vin_logger.go
+++ b/internal/loggers/vin_logger.go
@@ -26,7 +26,7 @@ func NewVINLogger() VINLogger {
 	return &vinLogger{}
 }
 
-const VINLoggerVersion = 1
+const VINLoggerVersion = 1 // increment this if improve support for decoding VINs
 const citroenQueryName = "citroen"
 
 func (vl *vinLogger) GetVIN(unitID uuid.UUID, queryName *string) (vinResp *VINResponse, err error) {

--- a/internal/loggers/vin_logger.go
+++ b/internal/loggers/vin_logger.go
@@ -88,6 +88,9 @@ func (vl *vinLogger) GetVIN(unitID uuid.UUID, queryName *string) (vinResp *VINRe
 	// if all PIDs fail, try passive scan, currently specific to Citroen
 	if err != nil {
 		vinResp, _ = passiveScanCitroen()
+		if vinResp != nil {
+			err = nil
+		}
 	}
 	return
 }


### PR DESCRIPTION
Need to better handle errors when we can't get the VIN. 

- better wrap errors, check doing this everywhere. 
- cleanup related to errros
- persist the vin_logger version in settings
- persist the vin_logger fail count
- if fail count for same version is > 3, stop trying to get the vin, until version changes