### PR TITLE
PRO-1591 return 0 if no err and 1 if some err during during request

### DIFF
--- a/commands/vehicle.go
+++ b/commands/vehicle.go
@@ -39,6 +39,7 @@ func ClearDiagnosticCodes(unitID uuid.UUID) (err error) {
 }
 
 func GetDiagnosticCodes(unitID uuid.UUID) (codes string, err error) {
+	codes = ""
 	req := api.ExecuteRawRequest{Command: api.GetDiagnosticCodeCommand}
 	path := fmt.Sprintf("/dongle/%s/execute_raw", unitID)
 
@@ -54,5 +55,6 @@ func GetDiagnosticCodes(unitID uuid.UUID) (codes string, err error) {
 		formattedResponse += s.Code + ","
 	}
 	codes = strings.TrimSuffix(formattedResponse, ",")
+
 	return
 }

--- a/main.go
+++ b/main.go
@@ -639,6 +639,7 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 
 	dtcChar.Properties.Flags = []string{gatt.FlagCharacteristicEncryptAuthenticatedRead, gatt.FlagCharacteristicEncryptAuthenticatedWrite}
 
+	// dtcChar will return error codes if found, if nothing found with a success will return "0", if nothing found but error response returns "1"
 	dtcChar.OnRead(func(c *service.Char, options map[string]interface{}) (resp []byte, err error) {
 		defer func() {
 			if err != nil {
@@ -654,11 +655,14 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 
 		codes, err := commands.GetDiagnosticCodes(unitID)
 		if err != nil {
-			resp = []byte("0")
+			resp = []byte("1")
 			return
 		}
-
 		log.Printf("Got Error Codes: %s", codes)
+
+		if len(codes) < 2 {
+			codes = "0"
+		}
 
 		resp = []byte(codes)
 		lastDTC = codes


### PR DESCRIPTION
to better handle errors in the frontend, we'll imitate unix systems ie. return "0" if no errors but succesful exit, and "1" if any kind of err was returned not allowing to succesfully get the errors. 
`lastDTC` will only be set if success, so that retrying actually hits the OBD again