### PR TITLE
Feature/si 2064

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,10 @@ require (
 	github.com/jarcoal/httpmock v1.3.0
 	github.com/muka/go-bluetooth v0.0.0-20200903202100-13616d14eca5
 	github.com/pkg/errors v0.9.1
+	github.com/segmentio/ksuid v1.0.4
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.0
+	github.com/tidwall/gjson v1.14.4
 	github.com/tidwall/sjson v1.2.5
 	go.einride.tech/can v0.5.5
 )
@@ -29,8 +31,6 @@ require (
 	github.com/mdlayher/netlink v1.7.1 // indirect
 	github.com/mdlayher/socket v0.4.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/segmentio/ksuid v1.0.4 // indirect
-	github.com/tidwall/gjson v1.14.4 // indirect
 	github.com/tidwall/match v1.1.1 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect

--- a/main.go
+++ b/main.go
@@ -851,15 +851,14 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 		log.Printf("Failed to autodetect a canbus: %s", err)
 	}
 
-	advertisedServices := []string{}
-	advertisedServices = append(advertisedServices, app.GenerateUUID(deviceServiceUUIDFragment))
+	advertisedServices := []string{app.GenerateUUID(deviceServiceUUIDFragment)}
 
 	cancel, err := app.Advertise(math.MaxUint32, name, advertisedServices)
 	if err != nil {
 		log.Fatalf("Failed advertising: %s", err)
 	}
 
-	signal, omSignalCancel, err := app.Adapter().GetObjectManagerSignal()
+	omSignal, omSignalCancel, err := app.Adapter().GetObjectManagerSignal()
 	if err != nil {
 		log.Fatalf("Failed to Get Signal")
 	}
@@ -872,7 +871,7 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 			}
 		}()
 
-		for v := range signal {
+		for v := range omSignal {
 
 			if v == nil {
 				return

--- a/main.go
+++ b/main.go
@@ -877,9 +877,7 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 			if v == nil {
 				return
 			}
-			if v.Name == bluez.InterfacesAdded {
-				continue
-			} else if v.Name == bluez.InterfacesRemoved {
+			if v.Name == bluez.InterfacesRemoved {
 				cmd.Exec("hciconfig", adapterID, "leadv 0")
 			} else {
 				continue

--- a/main.go
+++ b/main.go
@@ -877,7 +877,10 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 				return
 			}
 			if v.Name == bluez.InterfacesRemoved {
-				cmd.Exec("hciconfig", adapterID, "leadv 0")
+				_, err := cmd.Exec("hciconfig", adapterID, "leadv 0")
+				if err != nil {
+					log.Printf("error executing hciconfig: %s", err)
+				}
 			} else {
 				continue
 			}

--- a/main.go
+++ b/main.go
@@ -821,15 +821,6 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 		log.Fatalf("Failed to initialize app: %s", err)
 	}
 
-	advertisedServices := []string{}
-	advertisedServices = append(advertisedServices, app.GenerateUUID(deviceServiceUUIDFragment))
-	log.Printf("Advertising Packet: LocalName:%s ServiceUUID:%s", name, deviceService.Properties.UUID)
-
-	cancel, err := app.Advertise(math.MaxUint32, name, advertisedServices)
-	if err != nil {
-		log.Fatalf("Failed advertising: %s", err)
-	}
-
 	//Check if we should disable new connections
 	devices, err := app.Adapter().GetDevices()
 	if err != nil {
@@ -859,9 +850,12 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 		log.Printf("Failed to autodetect a canbus: %s", err)
 	}
 
-	err = btManager.SetAdvertising(true)
+	advertisedServices := []string{}
+	advertisedServices = append(advertisedServices, app.GenerateUUID(deviceServiceUUIDFragment))
+
+	cancel, err := app.Advertise(math.MaxUint32, name, advertisedServices)
 	if err != nil {
-		log.Fatalf("failed to set advertising on the controller: %s", err)
+		log.Fatalf("Failed advertising: %s", err)
 	}
 
 	log.Printf("Canbus Protocol Info: %v", canBusInformation)

--- a/main.go
+++ b/main.go
@@ -877,6 +877,7 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 				return
 			}
 			if v.Name == bluez.InterfacesRemoved {
+				// re-enables advertising, bug in the driver
 				_, err := cmd.Exec("hciconfig", adapterID, "leadv 0")
 				if err != nil {
 					log.Printf("error executing hciconfig: %s", err)

--- a/main.go
+++ b/main.go
@@ -821,7 +821,11 @@ func setupBluetoothApplication(coldBoot bool, vinLogger loggers.VINLogger, lss l
 		log.Fatalf("Failed to initialize app: %s", err)
 	}
 
-	cancel, err := app.Advertise(math.MaxUint32)
+	advertisedServices := []string{}
+	advertisedServices = append(advertisedServices, app.GenerateUUID(deviceServiceUUIDFragment))
+	log.Printf("Advertising Packet: LocalName:%s ServiceUUID:%s", name, deviceService.Properties.UUID)
+
+	cancel, err := app.Advertise(math.MaxUint32, name, advertisedServices)
 	if err != nil {
 		log.Fatalf("Failed advertising: %s", err)
 	}

--- a/service/app_advertise.go
+++ b/service/app_advertise.go
@@ -17,9 +17,14 @@ func (app *App) Advertise(timeout uint32, localName string, advertisedServices [
 
 	adv.Timeout = uint16(timeout)
 	adv.Duration = uint16(timeout)
+	adv.Discoverable = true
+	adv.DiscoverableTimeout = uint16(timeout)
 	adv.LocalName = localName
+	adv.Type = "peripheral"
 	adv.ServiceUUIDs = advertisedServices
 	cancel, err := api.ExposeAdvertisement(app.adapterID, adv, timeout)
+
+	log.Printf("Advertising Packet:%+v ", adv)
 
 	if err != nil {
 		log.Fatalf("Failed advertising: %s", err)

--- a/service/app_advertise.go
+++ b/service/app_advertise.go
@@ -11,18 +11,14 @@ func (app *App) GetAdvertisement() *advertising.LEAdvertisement1Properties {
 	return app.advertisement
 }
 
-func (app *App) Advertise(timeout uint32) (func(), error) {
+func (app *App) Advertise(timeout uint32, localName string, advertisedServices []string) (func(), error) {
 
 	adv := app.GetAdvertisement()
 
 	adv.Timeout = uint16(timeout)
 	adv.Duration = uint16(timeout)
-
-	serviceUUIDs := []string{}
-	for serviceUUID := range app.GetServices() {
-		serviceUUIDs = append(serviceUUIDs, string(serviceUUID))
-	}
-
+	adv.LocalName = localName
+	adv.ServiceUUIDs = advertisedServices
 	cancel, err := api.ExposeAdvertisement(app.adapterID, adv, timeout)
 
 	if err != nil {


### PR DESCRIPTION
Fixes the advertising issue and the service data is finally showing up in the packet. 

Logs before:
```
@ MGMT Command: Add Advertising (0x003e) plen 54                                                                                                                                                                          {0x0001} [hci0] 22.200819
        Instance: 1
        Flags: 0x00000003
          Switch into Connectable mode
          Advertise as Discoverable
        Duration: 65535
        Timeout: 0
        Advertising data length: 22
        128-bit Service UUIDs (complete): 1 entry
          Vendor specific (5c307fa4-6859-4d6c-a87b-8d2c98c9f6f0)
        Appearance: Unknown (0x0000)
        Scan response length: 21
        Name (complete): autopi-0296989ff67b
@ MGMT Event: Advertising Added (0x0023) plen 1                                                                                                                                                                           {0x0002} [hci0] 22.200850
        Instance: 1
@ MGMT Event: Command Complete (0x0001) plen 4                                                                                                                                                                            {0x0001} [hci0] 22.200871
      Add Advertising (0x003e) plen 1
        Status: Success (0x00)
        Instance: 1
```


Logs After:
```
@ MGMT Command: Add Advertising (0x003e) plen 57                                                                                                                                                                          {0x0001} [hci0] 60.205095
        Instance: 1
        Flags: 0x00000001
          Switch into Connectable mode
        Duration: 65535
        Timeout: 0
        Advertising data length: 25
        128-bit Service UUIDs (complete): 1 entry
          Vendor specific (5c307fa4-6859-4d6c-a87b-8d2c98c9f6f0)
        Appearance: Unknown (0x0000)
        Flags: 0x05
          LE Limited Discoverable Mode
          BR/EDR Not Supported
        Scan response length: 21
        Name (complete): autopi-0296989ff67b
@ MGMT Event: Advertising Added (0x0023) plen 1                                                                                                                                                                           {0x0002} [hci0] 60.205128
        Instance: 1
< HCI Command: LE Set Advertising Data (0x08|0x0008) plen 32                                                                                                                                                                   #83 [hci0] 60.205219
        Length: 25
        128-bit Service UUIDs (complete): 1 entry
          Vendor specific (5c307fa4-6859-4d6c-a87b-8d2c98c9f6f0)
        Appearance: Unknown (0x0000)
        Flags: 0x05
          LE Limited Discoverable Mode
          BR/EDR Not Supported
> HCI Event: Command Complete (0x0e) plen 4                                                                                                                                                                                    #84 [hci0] 60.205923
      LE Set Advertising Data (0x08|0x0008) ncmd 1
        Status: Success (0x00)
< HCI Command: LE Set Scan Response Data (0x08|0x0009) plen 32                                                                                                                                                                 #85 [hci0] 60.206006
        Length: 21
        Name (complete): autopi-0296989ff67b
> HCI Event: Command Complete (0x0e) plen 4                                                                                                                                                                                    #86 [hci0] 60.206411
      LE Set Scan Response Data (0x08|0x0009) ncmd 1
        Status: Success (0x00)
< HCI Command: LE Set Advertising Parameters (0x08|0x0006) plen 15                                                                                                                                                             #87 [hci0] 60.206486
        Min advertising interval: 1280.000 msec (0x0800)
        Max advertising interval: 1280.000 msec (0x0800)
        Type: Connectable undirected - ADV_IND (0x00)
        Own address type: Public (0x00)
        Direct address type: Public (0x00)
        Direct address: 00:00:00:00:00:00 (OUI 00-00-00)
        Channel map: 37, 38, 39 (0x07)
        Filter policy: Allow Scan Request from Any, Allow Connect Request from Any (0x00)
> HCI Event: Command Complete (0x0e) plen 4                                                                                                                                                                                    #88 [hci0] 60.206815
      LE Set Advertising Parameters (0x08|0x0006) ncmd 1
        Status: Success (0x00)
< HCI Command: LE Set Advertise Enable (0x08|0x000a) plen 1                                                                                                                                                                    #89 [hci0] 60.206889
        Advertising: Enabled (0x01)
> HCI Event: Command Complete (0x0e) plen 4                                                                                                                                                                                    #90 [hci0] 60.207258
      LE Set Advertise Enable (0x08|0x000a) ncmd 1
        Status: Success (0x00)
@ MGMT Event: Command Complete (0x0001) plen 4                                                                                                                                                                            {0x0001} [hci0] 60.207321
      Add Advertising (0x003e) plen 1
        Status: Success (0x00)
        Instance: 1
```

Before testing, check that in "NRF Connect", device does not show any uuids(service data) for the device.
After installing this version, try again. You should see service data under the device.