### PR TITLE
SM-765: pids hex to lower case

### DIFF
--- a/internal/loggers/dbc_formula_decoder.go
+++ b/internal/loggers/dbc_formula_decoder.go
@@ -30,7 +30,7 @@ func ExtractAndDecodeWithDBCFormula(hexData, pid, formula string) (float64, stri
 	}
 
 	// Find the index of PID in the sliced hex string
-	pidIndex := strings.Index(slicedHexData, pid)
+	pidIndex := strings.Index(strings.ToLower(slicedHexData), strings.ToLower(pid))
 	if pidIndex == -1 {
 		return 0, "", errors.New("PID not found")
 	}


### PR DESCRIPTION
- if pid decimal was converted to hex always in upper case, despite that in database we have hex containing lower case characters