### PR TITLE
SM-791 save template config URLs

### DIFF
--- a/main.go
+++ b/main.go
@@ -134,7 +134,7 @@ func main() {
 	// get the template settings from remote, below method handles all the special logic
 	pids, deviceSettings, err := vehicleTemplates.GetTemplateSettings(ethAddr)
 	if err != nil {
-		logger.Err(err).Msg("unable to get device settings (pids, dbc, settings)")
+		logger.Fatal().Err(err).Msg("unable to get device settings (pids, dbc, settings)")
 		// todo send mqtt error payload reporting this, should have own topic for errors
 	}
 	if pids != nil {


### PR DESCRIPTION
- save the template URL's locally, because we weren't doing this before, meaning we'd always be making config updates even if nothing had changed.
- fail startup if can't get configuration