### PR TITLE
intg-1866 dtc error codes implementation on vehicle start

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/DIMO-Network/edge-network/internal/util"
+	"github.com/DIMO-Network/edge-network/internal/util/retry"
 	"github.com/rs/zerolog"
 
 	"github.com/DIMO-Network/shared"
@@ -109,7 +109,7 @@ func ReadConfig(logger zerolog.Logger, configFiles embed.FS, configURL, configFi
 	// Get secrets from remote config
 	remoteConfigPathOnDisk := "/opt/autopi/remote-config.json"
 	// Retry for about 1 hour
-	remoteConfig, err := util.Retry[Config](11, 1*time.Second, logger, func() (interface{}, error) {
+	remoteConfig, err := retry.Retry[Config](11, 1*time.Second, logger, func() (interface{}, error) {
 		return GetRemoteConfig(configURL, remoteConfigPathOnDisk)
 	})
 

--- a/internal/dtcErrors.go
+++ b/internal/dtcErrors.go
@@ -1,0 +1,64 @@
+package internal
+
+import (
+	"fmt"
+	"github.com/DIMO-Network/edge-network/commands"
+	"github.com/DIMO-Network/edge-network/internal/models"
+	"github.com/DIMO-Network/edge-network/internal/network"
+	"github.com/google/uuid"
+	"github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"time"
+)
+
+type DtcErrorsRunner interface {
+	DtcErrors() error
+	CurrentFailureCount() int
+	//IncrementFailuresReached() int
+}
+
+type dtcErrorsRunner struct {
+	unitID     uuid.UUID
+	logger     zerolog.Logger
+	dataSender network.DataSender
+	// state tracking
+	failureCount int
+	// allTimeFailureCount is loaded from disk from last boot - used to determine edge-logging need. Increments by 1 per boot cycle even if retried many times in one boot
+	allTimeFailureCount int // not sure we'll use this.
+}
+
+func NewDtcErrorsRunner(unitID uuid.UUID, dataSender network.DataSender, logger zerolog.Logger) DtcErrorsRunner {
+	return &dtcErrorsRunner{
+		unitID:       unitID,
+		logger:       logger,
+		dataSender:   dataSender,
+		failureCount: 0,
+	}
+}
+
+func (ls *dtcErrorsRunner) CurrentFailureCount() int {
+	return ls.failureCount
+}
+
+// DtcErrors requests DTC scan from vehicle, if anything returned, sends a payload with signals data to device status
+func (ls *dtcErrorsRunner) DtcErrors() error {
+	codes, err := commands.GetDiagnosticCodes(ls.unitID, ls.logger)
+	if err != nil {
+		ls.failureCount++
+		return errors.Wrap(err, fmt.Sprintf("failed to scan for dtc. fail count since boot: %d", ls.failureCount))
+	}
+	if len(codes) > 0 {
+		// send the dtc in the signals using status topic. Seems pointless to send any other common data
+		ts := time.Now().UTC().UnixMilli()
+		s := models.DtcErrorsData{Vehicle: models.Vehicle{Signals: []models.SignalData{
+			{
+				Timestamp: ts,
+				Name:      "dtcErrors",
+				Value:     codes,
+			},
+		}}}
+		return ls.dataSender.SendDeviceStatusData(s)
+	}
+
+	return nil
+}

--- a/internal/dtcErrors.go
+++ b/internal/dtcErrors.go
@@ -2,13 +2,14 @@ package internal
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/DIMO-Network/edge-network/commands"
 	"github.com/DIMO-Network/edge-network/internal/models"
 	"github.com/DIMO-Network/edge-network/internal/network"
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog"
-	"time"
 )
 
 type DtcErrorsRunner interface {
@@ -23,8 +24,6 @@ type dtcErrorsRunner struct {
 	dataSender network.DataSender
 	// state tracking
 	failureCount int
-	// allTimeFailureCount is loaded from disk from last boot - used to determine edge-logging need. Increments by 1 per boot cycle even if retried many times in one boot
-	allTimeFailureCount int // not sure we'll use this.
 }
 
 func NewDtcErrorsRunner(unitID uuid.UUID, dataSender network.DataSender, logger zerolog.Logger) DtcErrorsRunner {

--- a/internal/dtcErrors.go
+++ b/internal/dtcErrors.go
@@ -52,7 +52,7 @@ func (ls *dtcErrorsRunner) DtcErrors() error {
 		s := models.DtcErrorsData{Vehicle: models.Vehicle{Signals: []models.SignalData{
 			{
 				Timestamp: ts,
-				Name:      "dtcErrors",
+				Name:      "obdDTCList", // vss name
 				Value:     codes,
 			},
 		}}}

--- a/internal/gateways/identity_api.go
+++ b/internal/gateways/identity_api.go
@@ -5,9 +5,8 @@ import (
 	"io"
 	"time"
 
-	"github.com/DIMO-Network/edge-network/internal/util"
-
 	"github.com/DIMO-Network/edge-network/config"
+	"github.com/DIMO-Network/edge-network/internal/util/retry"
 
 	"github.com/DIMO-Network/edge-network/internal/models"
 	"github.com/DIMO-Network/shared"
@@ -100,7 +99,7 @@ func (i *identityAPIService) fetchVehicleWithQuery(query string) (*models.Vehicl
 	}
 
 	if vehicleResponse.Data.AfterMarketDevice.Vehicle.TokenID == 0 {
-		return nil, util.Stop{Err: errors.New(ErrNotFound.Error())}
+		return nil, retry.Stop{Err: errors.New(ErrNotFound.Error())}
 	}
 
 	return &vehicleResponse.Data.AfterMarketDevice.Vehicle, nil

--- a/internal/models/network.go
+++ b/internal/models/network.go
@@ -43,9 +43,6 @@ type Device struct {
 }
 
 type Vehicle struct {
-	Make    string       `json:"make"`
-	Model   string       `json:"model"`
-	Year    int          `json:"year"`
 	Signals []SignalData `json:"signals,omitempty"`
 }
 

--- a/internal/models/network.go
+++ b/internal/models/network.go
@@ -89,6 +89,13 @@ type FingerprintData struct {
 	SoftwareVersion string  `json:"softwareVersion"`
 }
 
+type DtcErrorsData struct {
+	//CommonData
+	//Device  Device  `json:"device,omitempty"`
+	// Vehicle.Signals should contain the dtc errors
+	Vehicle Vehicle `json:"vehicle,omitempty"`
+}
+
 type CellInfo struct {
 	Details api.IntrafrequencyLteInfo `json:"details,omitempty"`
 	IP      string                    `json:"ip,omitempty"`

--- a/internal/util/retry/retry.go
+++ b/internal/util/retry/retry.go
@@ -1,4 +1,4 @@
-package util
+package retry
 
 import (
 	"time"

--- a/internal/worker_runner.go
+++ b/internal/worker_runner.go
@@ -306,12 +306,6 @@ func (wr *workerRunner) composeDeviceEvent(powerStatus api.PowerStatusResponse, 
 		statusData.Vehicle.Signals = appendSignalData(statusData.Vehicle.Signals, "wpa_state", wifi.WPAState, ts)
 		statusData.Vehicle.Signals = appendSignalData(statusData.Vehicle.Signals, "ssid", wifi.SSID, ts)
 	}
-	// add vehicle info if available
-	if wr.vehicleInfo != nil {
-		statusData.Vehicle.Make = wr.vehicleInfo.VehicleDefinition.Make
-		statusData.Vehicle.Model = wr.vehicleInfo.VehicleDefinition.Model
-		statusData.Vehicle.Year = wr.vehicleInfo.VehicleDefinition.Year
-	}
 
 	return statusData
 }

--- a/internal/worker_runner.go
+++ b/internal/worker_runner.go
@@ -144,7 +144,7 @@ func (wr *workerRunner) Run() {
 					errDtc := wr.dtcErrorsRunner.DtcErrors()
 					if errDtc != nil {
 						// keep trying until max failure reach
-						if wr.dtcErrorsRunner.CurrentFailureCount() == maxFingerprintFailures {
+						if wr.dtcErrorsRunner.CurrentFailureCount() == 3 {
 							wr.logger.Err(errDtc).Msg("failed to do vehicle dtc error scan - max failures reached")
 							dtcErrorsDone = true
 						}

--- a/internal/worker_runner.go
+++ b/internal/worker_runner.go
@@ -186,10 +186,12 @@ func (wr *workerRunner) Run() {
 			// compose the device event
 			s := wr.composeDeviceEvent(powerStatus, locationErr, location, wifiErr, wifi)
 
-			// send the cloud event
-			err = wr.dataSender.SendDeviceStatusData(s)
-			if err != nil {
-				wr.logger.Err(err).Msg("failed to send device status in loop")
+			if len(s.Vehicle.Signals) > 0 {
+				// send the cloud event only if it has signals
+				err = wr.dataSender.SendDeviceStatusData(s)
+				if err != nil {
+					wr.logger.Err(err).Msg("failed to send device status in loop")
+				}
 			}
 
 			if cellErr == nil || wifiErr == nil {

--- a/internal/worker_runner_test.go
+++ b/internal/worker_runner_test.go
@@ -33,7 +33,7 @@ func Test_workerRunner_NonObd(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	_, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	_, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 
 	const autoPiBaseURL = "http://192.168.4.1:9000"
 	wfPath := fmt.Sprintf("/dongle/%s/execute_raw/", unitID)
@@ -46,7 +46,7 @@ func Test_workerRunner_NonObd(t *testing.T) {
 		httpmock.NewStringResponder(200, `{"lat": 37.7749, "lon": -122.4194, "_stamp": "2024-02-29T17:17:30.534861"}`))
 
 	// Initialize workerRunner here with mocked dependencies
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 
 	// then
 	wifi, _, location, _, cellInfo, _ := wr.queryNonObd("ec2x")
@@ -69,7 +69,7 @@ func Test_workerRunner_Obd(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	_, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	_, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().Return(false)
 
 	const autoPiBaseURL = "http://192.168.4.1:9000"
@@ -101,7 +101,7 @@ func Test_workerRunner_Obd(t *testing.T) {
 	}
 
 	// Initialize workerRunner here with mocked dependencies
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 
 	// then
@@ -124,7 +124,7 @@ func Test_workerRunner_Obd_With_Python_Formula(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	_, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	_, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().Return(false)
 
 	const autoPiBaseURL = "http://192.168.4.1:9000"
@@ -159,7 +159,7 @@ func Test_workerRunner_Obd_With_Python_Formula(t *testing.T) {
 	}
 
 	// Initialize workerRunner here with mocked dependencies
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 
 	// then
@@ -183,7 +183,7 @@ func Test_workerRunner_OBD_and_NonObd(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().Return(false)
 
 	// mock powerstatus resp
@@ -207,7 +207,7 @@ func Test_workerRunner_OBD_and_NonObd(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 
 	// then
@@ -237,7 +237,7 @@ func Test_workerRunner_Run(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -274,7 +274,7 @@ func Test_workerRunner_Run(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	wr.stop = make(chan bool)
@@ -297,7 +297,7 @@ func Test_workerRunner_Run_withLocationQuery(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -355,7 +355,7 @@ func Test_workerRunner_Run_withLocationQuery(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	// since location consists from 4 signals, we should have more than 40 signals in the 5 sec interval
@@ -379,7 +379,7 @@ func Test_workerRunner_Run_sendSameSignalMultipleTimes(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -416,7 +416,7 @@ func Test_workerRunner_Run_sendSameSignalMultipleTimes(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 10 * time.Second
 	wr.stop = make(chan bool)
@@ -438,7 +438,7 @@ func Test_workerRunner_Run_sendSignalsWithDifferentInterval(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 	// mock power status resp
 	psPath := fmt.Sprintf("/dongle/%s/execute_raw/", unitID)
@@ -488,7 +488,7 @@ func Test_workerRunner_Run_sendSignalsWithDifferentInterval(t *testing.T) {
 	}
 
 	// Initialize workerRunner here with mocked dependencies
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 10 * time.Second
 	wr.stop = make(chan bool)
@@ -510,7 +510,7 @@ func Test_workerRunner_Run_failedToQueryPidTooManyTimes(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -556,7 +556,7 @@ func Test_workerRunner_Run_failedToQueryPidTooManyTimes(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 10 * time.Second
 	wr.stop = make(chan bool)
@@ -588,7 +588,7 @@ func Test_workerRunner_Run_failedToQueryPidButRecover(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -637,7 +637,7 @@ func Test_workerRunner_Run_failedToQueryPidButRecover(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 10 * time.Second
 	wr.stop = make(chan bool)
@@ -686,7 +686,7 @@ func Test_workerRunner_RunWithNotEnoughVoltage(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -741,7 +741,7 @@ func Test_workerRunner_RunWithNotEnoughVoltage(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	wr.stop = make(chan bool)
@@ -773,7 +773,7 @@ func Test_workerRunner_RunWithNotEnoughVoltage2(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -828,7 +828,7 @@ func Test_workerRunner_RunWithNotEnoughVoltage2(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	wr.stop = make(chan bool)
@@ -861,7 +861,7 @@ func Test_workerRunner_RunWithCantQueryLocation(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	psPath := fmt.Sprintf("/dongle/%s/execute_raw/", unitID)
@@ -901,7 +901,7 @@ func Test_workerRunner_RunWithCantQueryLocation(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	wr.stop = make(chan bool)
@@ -933,7 +933,7 @@ func Test_workerRunner_FilterWiFiWhenDisconnected(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 
-	vl, ds, ts, dbcS, ls := mockComponents(mockCtrl, unitID)
+	vl, ds, ts, dbcS, ls, dr := mockComponents(mockCtrl, unitID)
 	dbcS.EXPECT().UseNativeScanLogger().AnyTimes().Return(false)
 
 	// mock power status resp
@@ -975,7 +975,7 @@ func Test_workerRunner_FilterWiFiWhenDisconnected(t *testing.T) {
 		},
 	}
 
-	wr := createWorkerRunner(ts, ds, dbcS, ls, unitID)
+	wr := createWorkerRunner(ts, ds, dbcS, ls, dr, unitID)
 	wr.pids.Requests = requests
 	wr.sendPayloadInterval = 5 * time.Second
 	wr.stop = make(chan bool)
@@ -986,7 +986,7 @@ func Test_workerRunner_FilterWiFiWhenDisconnected(t *testing.T) {
 	wr.Stop()
 }
 
-func mockComponents(mockCtrl *gomock.Controller, unitID uuid.UUID) (*mock_loggers.MockVINLogger, *mock_network.MockDataSender, *mock_loggers.MockTemplateStore, *mock_loggers.MockDBCPassiveLogger, FingerprintRunner) {
+func mockComponents(mockCtrl *gomock.Controller, unitID uuid.UUID) (*mock_loggers.MockVINLogger, *mock_network.MockDataSender, *mock_loggers.MockTemplateStore, *mock_loggers.MockDBCPassiveLogger, FingerprintRunner, DtcErrorsRunner) {
 	vl := mock_loggers.NewMockVINLogger(mockCtrl)
 	ds := mock_network.NewMockDataSender(mockCtrl)
 	ts := mock_loggers.NewMockTemplateStore(mockCtrl)
@@ -1000,7 +1000,8 @@ func mockComponents(mockCtrl *gomock.Controller, unitID uuid.UUID) (*mock_logger
 	ts.EXPECT().ReadVINConfig().Times(1).Return(nil, fmt.Errorf("error reading file: open /tmp/logger-settings.json: no such file or directory"))
 
 	ls := NewFingerprintRunner(unitID, vl, ds, ts, logger)
-	return vl, ds, ts, dbcS, ls
+	dr := NewDtcErrorsRunner(unitID, ds, logger)
+	return vl, ds, ts, dbcS, ls, dr
 }
 
 func expectOnMocks(ts *mock_loggers.MockTemplateStore, vl *mock_loggers.MockVINLogger, unitID uuid.UUID, ds *mock_network.MockDataSender, readVinNum int) {
@@ -1011,12 +1012,13 @@ func expectOnMocks(ts *mock_loggers.MockTemplateStore, vl *mock_loggers.MockVINL
 	ds.EXPECT().SendFingerprintData(gomock.Any()).Times(1).Return(nil)
 }
 
-func createWorkerRunner(ts *mock_loggers.MockTemplateStore, ds *mock_network.MockDataSender, dbcS *mock_loggers.MockDBCPassiveLogger, ls FingerprintRunner, unitID uuid.UUID) *workerRunner {
+func createWorkerRunner(ts *mock_loggers.MockTemplateStore, ds *mock_network.MockDataSender, dbcS *mock_loggers.MockDBCPassiveLogger, ls FingerprintRunner, dr DtcErrorsRunner, unitID uuid.UUID) *workerRunner {
 	wr := &workerRunner{
 		loggerSettingsSvc: ts,
 		dataSender:        ds,
 		deviceSettings:    &models.TemplateDeviceSettings{},
 		fingerprintRunner: ls,
+		dtcErrorsRunner:   dr,
 		device: Device{
 			UnitID: unitID,
 		},

--- a/main.go
+++ b/main.go
@@ -11,9 +11,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DIMO-Network/edge-network/internal/util"
-
 	"github.com/DIMO-Network/edge-network/internal/hooks"
+	"github.com/DIMO-Network/edge-network/internal/util/retry"
 
 	"github.com/google/subcommands"
 	"github.com/sirupsen/logrus"
@@ -77,7 +76,7 @@ func main() {
 	logger.Info().Msgf("hardware version found: %s", hwRevision)
 
 	// retry logic for getting ethereum address
-	ethAddr, ethErr := util.Retry[common.Address](3, 5*time.Second, logger, func() (interface{}, error) {
+	ethAddr, ethErr := retry.Retry[common.Address](3, 5*time.Second, logger, func() (interface{}, error) {
 		return commands.GetEthereumAddress(unitID)
 	})
 
@@ -274,7 +273,7 @@ func setupBluez(name string) error {
 // getVehicleInfo queries identity-api with 3 retries logic, to get vehicle to device pairing info (vehicle NFT)
 func getVehicleInfo(logger zerolog.Logger, ethAddr *common.Address, conf dimoConfig.Config) (*models.VehicleInfo, error) {
 	identityAPIService := gateways.NewIdentityAPIService(logger, conf)
-	vehicleDefinition, err := util.Retry[models.VehicleInfo](3, 1*time.Second, logger, func() (interface{}, error) {
+	vehicleDefinition, err := retry.Retry[models.VehicleInfo](3, 1*time.Second, logger, func() (interface{}, error) {
 		v, err := identityAPIService.QueryIdentityAPIForVehicle(*ethAddr)
 		if v != nil && v.TokenID == 0 {
 			return nil, fmt.Errorf("failed to query identity api for vehicle info - tokenId is zero")

--- a/main.go
+++ b/main.go
@@ -209,6 +209,7 @@ func main() {
 	signal.Notify(sigChan, os.Interrupt)
 
 	fingerprintRunner := internal.NewFingerprintRunner(unitID, vinLogger, ds, lss, logger)
+	dtcRunner := internal.NewDtcErrorsRunner(unitID, ds, logger)
 	dbcScanner := loggers.NewDBCPassiveLogger(logger, dbcFile, hwRevision, pids)
 
 	// query imei
@@ -225,7 +226,7 @@ func main() {
 		IMEI:            imei,
 	}
 	// Execute Worker in background.
-	runnerSvc := internal.NewWorkerRunner(ethAddr, lss, ds, logger, fingerprintRunner, pids, deviceSettings, deviceConf, vehicleInfo, dbcScanner)
+	runnerSvc := internal.NewWorkerRunner(ethAddr, lss, ds, logger, fingerprintRunner, pids, deviceSettings, deviceConf, vehicleInfo, dbcScanner, dtcRunner)
 	runnerSvc.Run() // not sure if this will block always. if it does do we need to have a cancel when catch os.Interrupt, ie. stop tasks?
 
 	sig := <-sigChan


### PR DESCRIPTION
Run DTC error cods command on vehicle start, same flow as we do for fingerprint.

This just re-uses the signals data on the device status topic. This does not set some of the common data or the vehicle make model year as it seems useless for this feature. Will need to double check this isn't a problem for ingest. 

Signal name that will be mapped is `dtcErrors` and the value can be comma delimited - which we'll need to handle for telemetry ingest.